### PR TITLE
Improve error message when unsupported platform is used

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -473,8 +473,9 @@ async function main() {
   const SUPPORTED_PLATFORMS = ['claude', 'codex', 'gemini', 'copilot', 'cursor', 'windsurf', 'aider', 'opencode'];
   if (!SUPPORTED_PLATFORMS.includes(options.platform)) {
     console.error(`\n  Error: Unsupported platform '${options.platform}'.`);
-    console.error(`  Why: Only the following platforms are supported: ${SUPPORTED_PLATFORMS.join(', ')}.`);
-    console.error(`  Fix: Use --platform with one of the supported values, e.g.: npx nerviq --platform claude`);
+    console.error(`  Supported platforms: ${SUPPORTED_PLATFORMS.join(', ')}.`);
+    console.error(`  To get started: npx nerviq setup`);
+    console.error(`  To diagnose issues: npx nerviq doctor`);
     console.error('  Docs: https://github.com/nerviq/nerviq#cross-platform\n');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Improves the error message when users specify an unsupported platform with `--platform`. Adds helpful suggestions to guide users on next steps.

## Changes

- Added "To get started: npx nerviq setup" suggestion
- Added "To diagnose issues: npx nerviq doctor" suggestion
- Simplified the message format for clarity

## Before

Error: Unsupported platform 'nonexistent'.
Why: Only the following platforms are supported: claude, codex, gemini...
Fix: Use --platform with one of the supported values

## After
Error: Unsupported platform 'nonexistent'.
Supported platforms: claude, codex, gemini, copilot, cursor...
To get started: npx nerviq setup
To diagnose issues: npx nerviq doctor

Fixes #9